### PR TITLE
fix(supabase): keepalive anti-pause plus robuste

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ SUPABASE_SECRET_KEY=sb_secret_xxx
 # --- App --------------------------------------------------------------
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# Cron Vercel → /api/keepalive (anti-pause Supabase free).
+# Sur Vercel : Settings → Environment Variables → CRON_SECRET.
+# Vercel envoie automatiquement Authorization: Bearer $CRON_SECRET.
+CRON_SECRET=
+
 # Dev / preview uniquement : désactive le garde-fou d'abonnement.
 # Permet de créer/sauver des tactiques sans Stripe configuré.
 # En prod : LAISSE VIDE OU "false".

--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -1,15 +1,24 @@
 name: Supabase keepalive
 
-# Empeche le projet Supabase free de se mettre en pause :
-# une requete par jour suffit a compter comme activite.
+# Empêche le projet Supabase free de se mettre en pause (7 jours d'inactivité).
+# Une requête API/DB réelle suffit ; le dashboard ne compte PAS.
+#
+# Attention GitHub : les workflows schedule sont désactivés après 60 jours
+# SANS activité sur le repo (push/PR). Les runs du cron ne comptent pas.
+# Contre-mesure : cron Vercel sur /api/keepalive (voir vercel.json).
 on:
   schedule:
-    - cron: "17 6 * * *" # tous les jours a 06:17 UTC
+    # 2×/jour : GitHub peut retarder/skipper un cron, on se couvre
+    - cron: "17 6 * * *" # 06:17 UTC
+    - cron: "41 18 * * *" # 18:41 UTC
   workflow_dispatch:
 
 concurrency:
   group: supabase-keepalive
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   ping:
@@ -40,6 +49,7 @@ jobs:
             echo "-> ${label} (${path})"
             local status
             status=$(curl -sS -o /tmp/body.txt -w "%{http_code}" \
+              --max-time 30 \
               -H "apikey: ${SUPABASE_PUBLISHABLE_KEY}" \
               -H "Authorization: Bearer ${SUPABASE_PUBLISHABLE_KEY}" \
               -H "Accept: application/json" \
@@ -56,6 +66,7 @@ jobs:
 
           ok=0
           if ping "auth health" "/auth/v1/health"; then ok=1; fi
+          # Requête REST = vraie activité DB (c'est ça qui empêche la pause)
           if ping "rest profiles" "/rest/v1/profiles?select=id&limit=1"; then ok=1; fi
 
           if [ "${ok}" -eq 0 ]; then

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Toutes les positions (joueurs, ballon, mouvements) sont stockées en `[0, 1]` pl
 2. **Premier clone** : `cp .env.example .env` puis remplir localement.
 3. **CI** : `.github/workflows/ci.yml` exécute sur chaque push / PR (`main` ou `master`) : `npm ci`, lint, `type-check`, tests Vitest, `next build` avec des variables factices. Les *warnings* ESLint ne font pas échouer le workflow.
 4. **Prod** : variables réelles uniquement dans l’hébergeur (Vercel, etc.), pas dans git.
+5. **Anti-pause Supabase (free)** : le free tier pause après ~7j sans requête API/DB. Deux filets :
+   - GitHub Actions `.github/workflows/supabase-keepalive.yml` (2×/jour) — secrets repo `SUPABASE_URL` + `SUPABASE_PUBLISHABLE_KEY`. ⚠️ GitHub **désactive** les schedules après **60j sans push/PR** sur le repo (les runs du cron ne comptent pas).
+   - Cron Vercel `vercel.json` → `GET /api/keepalive` (1×/jour). Définis `CRON_SECRET` en prod ; Vercel l’envoie en `Authorization: Bearer …`.
+   - Alternative ultime : passer en Pro (pas de pause).
 
 ## Hors scope (roadmap)
 

--- a/src/app/api/keepalive/route.ts
+++ b/src/app/api/keepalive/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import {
+  getSupabasePublishableKey,
+  getSupabaseUrl,
+} from "@/lib/supabase/env";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Heartbeat pour empêcher la pause du projet Supabase free (7j d'inactivité).
+ * Appelé par le cron Vercel (vercel.json) — backup du workflow GitHub Actions
+ * qui peut être désactivé après 60j sans activité repo.
+ *
+ * Auth : `Authorization: Bearer $CRON_SECRET` (recommandé).
+ * Sans CRON_SECRET, on accepte uniquement les requêtes Vercel Cron
+ * (`x-vercel-cron: 1`).
+ */
+export async function GET(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  const auth = request.headers.get("authorization");
+  const isVercelCron = request.headers.get("x-vercel-cron") === "1";
+
+  if (cronSecret) {
+    if (auth !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+    }
+  } else if (!isVercelCron) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const url = getSupabaseUrl().replace(/\/$/, "");
+  const key = getSupabasePublishableKey();
+  const headers = {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+    Accept: "application/json",
+  };
+
+  const checks: Record<string, number> = {};
+
+  try {
+    const authRes = await fetch(`${url}/auth/v1/health`, {
+      headers,
+      cache: "no-store",
+      signal: AbortSignal.timeout(25_000),
+    });
+    checks.auth = authRes.status;
+
+    const restRes = await fetch(`${url}/rest/v1/profiles?select=id&limit=1`, {
+      headers,
+      cache: "no-store",
+      signal: AbortSignal.timeout(25_000),
+    });
+    checks.rest = restRes.status;
+
+    const ok = [checks.auth, checks.rest].some((s) => s === 200 || s === 206);
+    if (!ok) {
+      return NextResponse.json(
+        { ok: false, checks, at: new Date().toISOString() },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      checks,
+      at: new Date().toISOString(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "ping failed";
+    return NextResponse.json(
+      { ok: false, error: message, at: new Date().toISOString() },
+      { status: 502 },
+    );
+  }
+}

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -15,6 +15,20 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
 NEXT_PUBLIC_STRIPE_PRICE_ID=price_...
 ```
 
+## Anti-pause (free tier)
+
+Supabase pause les projets free après ~7 jours sans activité API/DB (le dashboard ne compte pas).
+
+Déjà branché dans ce repo :
+
+1. **GitHub Actions** — `.github/workflows/supabase-keepalive.yml`  
+   Secrets : `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`  
+   Relancer manuellement : Actions → *Supabase keepalive* → *Run workflow*  
+   ⚠️ Désactivé auto après 60j sans activité git sur le repo.
+
+2. **Cron Vercel** — `GET /api/keepalive` via `vercel.json`  
+   Env : `CRON_SECRET` (+ les `NEXT_PUBLIC_SUPABASE_*` déjà en prod)
+
 ## Appliquer la migration
 
 Option A — via Supabase CLI (recommandé) :

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/keepalive",
+      "schedule": "0 6 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Contexte

Le free tier Supabase pause après ~7j sans requête API/DB. On avait déjà un workflow GitHub Actions, mais il s’est **arrêté le 11 juillet** : GitHub désactive les schedules après **60j sans activité git** (dernier push = 11 mai). Les runs du cron ne comptent pas.

## Changements

- **GitHub Actions** : 2×/jour + timeout curl + doc du piège 60j
- **Cron Vercel** (`vercel.json`) → `GET /api/keepalive` qui ping auth + REST `profiles`
- Docs README / supabase / `.env.example` (`CRON_SECRET`)

## À faire après merge

1. Actions → *Supabase keepalive* → *Run workflow* (relance le schedule)
2. Sur Vercel : ajouter `CRON_SECRET` (Vercel l’envoie auto en Bearer)
3. Vérifier que les secrets repo `SUPABASE_URL` + `SUPABASE_PUBLISHABLE_KEY` sont toujours là

Alternative définitive : passer en Pro (pas de pause).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88570c64-3111-4d46-b8f1-7ea24641ecbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88570c64-3111-4d46-b8f1-7ea24641ecbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

